### PR TITLE
[WIP] Improve performance of racer requests

### DIFF
--- a/src/bin/racerd.rs
+++ b/src/bin/racerd.rs
@@ -68,7 +68,7 @@ fn main() {
     let config: Config = args.into();
 
     // TODO start specified semantic engine. For now, hard coded racer.
-    let racer = engine::Racer;
+    let racer = engine::Racer::new();
     racer.initialize(&config).unwrap();
 
     // Start serving

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -8,7 +8,7 @@ pub use self::error::{Error, Result};
 use ::Config;
 
 /// Provide completions, definitions, and analysis of rust source code
-pub trait SemanticEngine {
+pub trait SemanticEngine : Send + Sync {
     /// Perform any necessary initialization.
     ///
     /// Only needs to be called once when an engine is created.

--- a/src/engine/racer.rs
+++ b/src/engine/racer.rs
@@ -7,29 +7,57 @@ use racer::scopes::{coords_to_point, point_to_coords};
 
 use std::path::Path;
 
+use std::sync::Mutex;
+
 pub struct Racer<'a> {
-    session: Session<'a>
+    session: Mutex<&'a Session<'a>>
 }
 
 impl<'a> Racer<'a> {
     pub fn new() -> Racer<'a> {
         let path = &Path::new("hopefully/never/a/real/path/as/long/as/this/hack/exists/.com");
+
+        // The unsafe block in the constructor is taking ownership of the Session allocated by this
+        // box. It is later freed in the drop impl. Having a Session reference with the same
+        // lifetime as Racer solves a concrete self lifetime problem in the SemanticEngine
+        // implementation.
+        //
+        // The following unsafe block should be fine since the memory is known to be valid. The
+        // reference will have the same value for the lifetime of the Racer object, so there is no
+        // need to worry about stale references wandering around. However, I am not certain that
+        // MutexGuard will save us from references escaping a critical section since you normally
+        // cannot store references in a Mutex. At this time, that's not a problem, but it would be
+        // good to have a static guarantee about not leaking references.
+        let session = Box::new(Session::from_path(path, path));
+        let session_ptr = Box::into_raw(session);
         Racer {
-            session: Session::from_path(path, path)
+            session: Mutex::new(unsafe { &*session_ptr })
         }
     }
 
-    pub fn build_racer_args<'b>(&'a self, ctx: &'b Context) -> (&'a Session, usize, &'b Path) {
+    pub fn build_racer_args<'b>(&self, ctx: &'b Context) -> (&'a str, usize, &'b Path) {
         let path = ctx.query_path();
+        let session = self.session.lock().unwrap();
 
         for buffer in &ctx.buffers {
-            self.session.cache_file_contents(buffer.path(), &buffer.contents[..]);
+            session.cache_file_contents(buffer.path(), &buffer.contents[..]);
         }
 
-        let query_src = &self.session.load_file(path).src.code[..];
+        let query_src = &session.load_file(path).src.code[..];
         let pos = coords_to_point(query_src, ctx.query_cursor.line, ctx.query_cursor.col);
 
-        (&self.session, pos, path)
+        (query_src, pos, path)
+    }
+}
+
+impl<'a> Drop for Racer<'a> {
+    fn drop(&mut self) {
+        let session_ref = *self.session.lock().unwrap();
+        // At this point, nobody has a reference to the session because it is locked behind the
+        // mutex and the lock is held here. Nobody has a reference to the mutex because its holder
+        // is being dropped. Thus, casting a non mutable reference to a raw *mut pointer to
+        // reconstitute the box should be fine.
+        let _session: Box<Session> = unsafe { Box::from_raw(::std::mem::transmute(session_ref)) };
     }
 }
 
@@ -46,11 +74,12 @@ impl<'a> SemanticEngine for Racer<'a> {
     }
 
     fn find_definition(&self, ctx: &Context) -> Result<Option<Definition>> {
-        let (session, pos, path) = self.build_racer_args(ctx);
+        let (query_src, pos, path) = self.build_racer_args(ctx);
+        let session = self.session.lock().unwrap();
 
         // TODO catch_panic: apparently this can panic! in a string operation. Something about pos
         // not landing on a character boundary.
-        Ok(match ::racer::core::find_definition("", path, pos, session) {
+        Ok(match ::racer::core::find_definition(query_src, path, pos, *session) {
             Some(m) => {
                 // TODO modify racer Match to return line, col. For now, read the file it found a
                 // match in to translate the Match position into line, col.
@@ -78,9 +107,10 @@ impl<'a> SemanticEngine for Racer<'a> {
     }
 
     fn list_completions(&self, ctx: &Context) -> Result<Option<Vec<Completion>>> {
-        let (session, pos, path) = self.build_racer_args(ctx);
+        let (query_src, pos, path) = self.build_racer_args(ctx);
+        let session = self.session.lock().unwrap();
 
-        let matches = ::racer::core::complete_from_file("", path, pos, session);
+        let matches = ::racer::core::complete_from_file(query_src, path, pos, *session);
 
         let completions = matches.map(|m| {
             let (line, col) = {
@@ -109,6 +139,9 @@ impl<'a> SemanticEngine for Racer<'a> {
         }
     }
 }
+
+unsafe impl<'a> Sync for Racer<'a> {}
+unsafe impl<'a> Send for Racer<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/racer.rs
+++ b/src/engine/racer.rs
@@ -5,12 +5,38 @@ use engine::{SemanticEngine, Definition, Context, CursorPosition, Completion};
 use racer::core::Session;
 use racer::scopes::{coords_to_point, point_to_coords};
 
-pub struct Racer;
+use std::path::Path;
+
+pub struct Racer<'a> {
+    session: Session<'a>
+}
+
+impl<'a> Racer<'a> {
+    pub fn new() -> Racer<'a> {
+        let path = &Path::new("hopefully/never/a/real/path/as/long/as/this/hack/exists/.com");
+        Racer {
+            session: Session::from_path(path, path)
+        }
+    }
+
+    pub fn build_racer_args<'b>(&'a self, ctx: &'b Context) -> (&'a Session, usize, &'b Path) {
+        let path = ctx.query_path();
+
+        for buffer in &ctx.buffers {
+            self.session.cache_file_contents(buffer.path(), &buffer.contents[..]);
+        }
+
+        let query_src = &self.session.load_file(path).src.code[..];
+        let pos = coords_to_point(query_src, ctx.query_cursor.line, ctx.query_cursor.col);
+
+        (&self.session, pos, path)
+    }
+}
 
 use ::Config;
 use super::Result;
 
-impl SemanticEngine for Racer {
+impl<'a> SemanticEngine for Racer<'a> {
     fn initialize(&self, config: &Config) -> Result<()> {
         if let Some(ref src_path) = config.rust_src_path {
             ::std::env::set_var("RUST_SRC_PATH", &src_path[..]);
@@ -20,23 +46,11 @@ impl SemanticEngine for Racer {
     }
 
     fn find_definition(&self, ctx: &Context) -> Result<Option<Definition>> {
-        // -----------------------------------------------------------------------------------------
-        // TODO: Refactor this block into a function. There was some lifetime issues I couldn't
-        // track down originally, and this chunk of code is used in a couple of places.
-        let path = ctx.query_path();
-        let session = Session::from_path(path, path);
-
-        for buffer in &ctx.buffers {
-            session.cache_file_contents(buffer.path(), &buffer.contents[..]);
-        }
-
-        let query_src = &session.load_file(path).src.code[..];
-        let pos = coords_to_point(query_src, ctx.query_cursor.line, ctx.query_cursor.col);
-        // -----------------------------------------------------------------------------------------
+        let (session, pos, path) = self.build_racer_args(ctx);
 
         // TODO catch_panic: apparently this can panic! in a string operation. Something about pos
         // not landing on a character boundary.
-        Ok(match ::racer::core::find_definition(query_src, path, pos, &session) {
+        Ok(match ::racer::core::find_definition("", path, pos, session) {
             Some(m) => {
                 // TODO modify racer Match to return line, col. For now, read the file it found a
                 // match in to translate the Match position into line, col.
@@ -64,23 +78,9 @@ impl SemanticEngine for Racer {
     }
 
     fn list_completions(&self, ctx: &Context) -> Result<Option<Vec<Completion>>> {
-        // -----------------------------------------------------------------------------------------
-        // TODO: Refactor this block into a function. There was some lifetime issues I couldn't
-        // track down originally, and this chunk of code is used in a couple of places.
-        let path = ctx.query_path();
-        let session = Session::from_path(path, path);
+        let (session, pos, path) = self.build_racer_args(ctx);
 
-        for buffer in &ctx.buffers {
-            session.cache_file_contents(buffer.path(), &buffer.contents[..]);
-        }
-
-        let query_src = &session.load_file(path).src.code[..];
-        let pos = ::racer::scopes::coords_to_point(query_src,
-                                                   ctx.query_cursor.line,
-                                                   ctx.query_cursor.col);
-        // -----------------------------------------------------------------------------------------
-
-        let matches = ::racer::core::complete_from_file(query_src, path, pos, &session);
+        let matches = ::racer::core::complete_from_file("", path, pos, session);
 
         let completions = matches.map(|m| {
             let (line, col) = {
@@ -139,7 +139,7 @@ mod tests {
         }];
 
         let ctx = Context::new(buffers, CursorPosition { line: 5, col: 17 }, "src.rs");
-        let racer = Racer;
+        let racer = Racer::new();
         let def = racer.find_definition(&ctx).unwrap().unwrap();
 
         assert_eq!(def.text, "myfn");
@@ -164,7 +164,7 @@ mod tests {
         }];
 
         let ctx = Context::new(buffers, CursorPosition { line: 8, col: 25 }, "src.rs");
-        let racer = Racer;
+        let racer = Racer::new();
 
         let completions = racer.list_completions(&ctx).unwrap().unwrap();
         assert_eq!(completions.len(), 1);

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -77,7 +77,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub struct EngineProvider;
 
 impl Key for EngineProvider {
-    type Value = Box<SemanticEngine + Send>;
+    type Value = Box<SemanticEngine + Send + Sync>;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -100,7 +100,7 @@ impl Key for EngineProvider {
 /// server.close().unwrap();
 /// ```
 ///
-pub fn serve<E: SemanticEngine + Send + 'static>(config: &Config, engine: E) -> Result<Server> {
+pub fn serve<E: SemanticEngine + 'static>(config: &Config, engine: E) -> Result<Server> {
     use persistent::{Read, Write};
     use logger::Logger;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -93,7 +93,7 @@ impl Key for EngineProvider {
 /// let mut cfg = Config::new();
 /// cfg.port = 3000;
 ///
-/// let engine = ::libracerd::engine::Racer;
+/// let engine = ::libracerd::engine::Racer::new();
 ///
 /// let mut server = ::libracerd::http::serve(&cfg, engine).unwrap();
 /// // ... later
@@ -157,7 +157,7 @@ impl Server {
     /// let mut config = ::libracerd::Config::new();
     /// config.port = 3000;
     ///
-    /// let engine = ::libracerd::engine::Racer;
+    /// let engine = ::libracerd::engine::Racer::new();
     /// let server = ::libracerd::http::serve(&config, engine).unwrap();
     ///
     /// assert_eq!(server.addr(), "0.0.0.0:3000");

--- a/tests/util/http.rs
+++ b/tests/util/http.rs
@@ -12,7 +12,7 @@ pub struct TestServer {
 
 impl TestServer {
     pub fn new() -> TestServer {
-        let engine = Racer;
+        let engine = Racer::new();
         let config = Config {
             port: 0,
             secret_file: "/tmp/secret".to_string(),


### PR DESCRIPTION
Finding completions for lines like `use std::` and `use std::io::` take ~100ms presently. Each request must read numerous std library files from disk. To fix this, we should reuse the [Session][] object for multiple requests. The [Session][] object keeps a cache of source files and could prevent lots of IO for files that will never change.

## Conflicting Lifetime Requirements

**TLDR:** Need concrete lifetime in trait method for `&'a self`, but this conflicts with trait definition. Attempting to make the compiler happy resulted in a less happy compiler and lifetime annotations everywhere.

I'm failing at meeting some lifetime constraints of the [Session][] object, its methods, and ultimately the [FileCache][] object it uses internally. You can see that the [Session][] type has a lifetime parameter `'s` which imposes a lifetime parameter on the [Racer][] struct that contains it.

```rust
// in racer/src/racer/core.rs
struct Session<'s> {
    // Fields omitted...
}

// in this project's src/engine/racer.rs
struct Racer<'s> {
    session: Session<'s>
}
```

We use the following methods from [Session][] when preparing to handle requests.

```rust
impl<'s> Session<'s> {
    pub fn load_file(&'s self, /* ... */) -> Src<'s> {
        // ...
    }

    pub fn cache_file_contents(&'s self, /* ... */) {
        // ...
    }
}
```

The `'s` lifetime on the self reference is required for the underlying [FileCache][] (also in racer/src/racer/core.rs). This requirement it thus imposed on one of the [Racer][] type's functions.

```rust
impl<'a> Racer<'a> {
    pub fn build_racer_args<'b>(&'a self, ctx: &'b Context) -> (&'a Session, usize, &'b Path) {}
}
```

`build_racer_args` is ultimately used within the [SemanticEngine][] trait's `find_definition` and `list_completions` implementations for [Racer][]. When compiling this code as-is, the compiler points out our conflicting lifetime requirements on `&self` for these methods.

```rust
   Compiling libracerd v0.1.0 (file:///Users/jwilm/code/racerd)
src/engine/racer.rs:49:41: 49:62 error: cannot infer an appropriate lifetime for autoref due to conflicting requirements [E0495]
src/engine/racer.rs:49         let (session, pos, path) = self.build_racer_args(ctx);
                                                               ^~~~~~~~~~~~~~~~~~~~~
src/engine/racer.rs:48:5: 78:6 help: consider using an explicit lifetime parameter as shown: fn find_definition(&'a self, ctx: &Context) -> Result<Option<Definition>>
src/engine/racer.rs:48     fn find_definition(&self, ctx: &Context) -> Result<Option<Definition>> {
src/engine/racer.rs:49         let (session, pos, path) = self.build_racer_args(ctx);
src/engine/racer.rs:50
src/engine/racer.rs:51         // TODO catch_panic: apparently this can panic! in a string operation. Something about pos
src/engine/racer.rs:52         // not landing on a character boundary.
src/engine/racer.rs:53         Ok(match ::racer::core::find_definition("", path, pos, session) {
                       ...
```

So naturally we will do as the compiler suggests and add the explicit lifetime bound to the functions. This results in a new error where we have a concrete lifetime where it expects a lifetime bound for the trait method and that this incompatible with the [SemanticEngine][] trait.

```rust
   Compiling libracerd v0.1.0 (file:///Users/jwilm/code/racerd)
src/engine/racer.rs:48:5: 78:6 error: method `find_definition` has an incompatible type for trait:
 expected bound lifetime parameter ,
    found concrete lifetime [E0053]
src/engine/racer.rs:48     fn find_definition(&'a self, ctx: &Context) -> Result<Option<Definition>> {
src/engine/racer.rs:49         let (session, pos, path) = self.build_racer_args(ctx);
src/engine/racer.rs:50
src/engine/racer.rs:51         // TODO catch_panic: apparently this can panic! in a string operation. Something about pos
src/engine/racer.rs:52         // not landing on a character boundary.
src/engine/racer.rs:53         Ok(match ::racer::core::find_definition("", path, pos, session) {
                       ...
```

At this point, I'm very lost on what to do. I tried forwarding the lifetime up through the trait and consumers of the trait, but I couldn't get that to work either, and there were lifetime annotations _everywhere_. I even looked at using `Rc` in the underlying racer types (instead of references from an Arena), but the changes required for this turned out to be extensive.

[Session]: https://github.com/jwilm/racer/blob/master/src/racer/core.rs#L350
[FileCache]: https://github.com/jwilm/racer/blob/master/src/racer/core.rs#L340
[SemanticEngine]: https://github.com/jwilm/racerd/blob/reuse-racer-session/src/engine/mod.rs#L11
[Racer]: https://github.com/jwilm/racerd/blob/reuse-racer-session/src/engine/mod.rs#L11