### PR TITLE
Add hmac auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ logger = { git = "https://github.com/iron/logger.git" }
 log = "*"
 rand = "*"
 env_logger = "*"
+iron-hmac = "0.1"
 
 [dependencies.racer] # requires beta or nightly
 # When making changes to racer, it's helpful to use a local path dependency.
@@ -24,6 +25,10 @@ env_logger = "*"
 # on jwilm's fork.
 git = "https://github.com/jwilm/racer.git"
 rev = "ba9dc11b7f5809944a47a791b63b0455e64c5ca2"
+
+[dev-dependencies]
+hyper = "0.7"
+openssl = "0.7"
 
 [dev-dependencies.json-request]
 # Small request library built for testing this project. Local path dep is handy

--- a/src/bin/racerd.rs
+++ b/src/bin/racerd.rs
@@ -15,7 +15,7 @@ const USAGE: &'static str = "
 racerd - a JSON/HTTP layer on top of racer
 
 Usage:
-  racerd serve --secret-file=<path> [--port=<int>] [-l] [--rust-src-path=<path>]
+  racerd serve [--secret-file=<path>] [--port=<int>] [-l] [--rust-src-path=<path>]
   racerd (-h | --help)
   racerd --version
 
@@ -32,7 +32,7 @@ Options:
 struct Args {
     flag_port: u16,
     flag_version: bool,
-    flag_secret_file: String,
+    flag_secret_file: Option<String>,
     flag_logging: bool,
     flag_rust_src_path: Option<String>,
     cmd_serve: bool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod engine;
 #[derive(Debug, Default)]
 pub struct Config {
     pub port: u16,
-    pub secret_file: String,
+    pub secret_file: Option<String>,
     pub print_http_logs: bool,
     pub rust_src_path: Option<String>
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
 //!
 //! This project's source code is [available on GitHub](https://github.com/jwilm/racerd).
 
-#[deny(dead_code)]
-#[deny(unused_variables)]
+#![deny(warnings)]
 
 extern crate rustc_serialize;
 
@@ -17,6 +16,7 @@ extern crate bodyparser; // Iron body parsing middleware
 extern crate persistent; // Iron storage middleware
 extern crate logger;     // Iron logging middleware
 extern crate iron;       // http framework
+extern crate iron_hmac;
 
 extern crate hyper;      // Provides `Listening` type returned by Iron
 
@@ -29,6 +29,9 @@ extern crate rand;
 pub mod util;
 pub mod http;
 pub mod engine;
+
+use std::io::Read;
+use std::fs::File;
 
 /// Configuration flags and values
 ///
@@ -45,5 +48,23 @@ impl Config {
     /// Build a default config object
     pub fn new() -> Config {
         Default::default()
+    }
+
+    /// Return contents of secret file
+    ///
+    /// panics if self.secret_file is None or an error is encountered while reading the file.
+    pub fn read_secret_file(&self) -> String {
+        self.secret_file.as_ref().map(|secret_file_path| {
+            let buf = {
+                let mut f = File::open(secret_file_path).unwrap();
+                let mut buf = String::new();
+                f.read_to_string(&mut buf).unwrap();
+                buf
+            };
+
+            ::std::fs::remove_file(secret_file_path).unwrap();
+
+            buf
+        }).unwrap()
     }
 }

--- a/tests/util/http.rs
+++ b/tests/util/http.rs
@@ -15,7 +15,7 @@ impl TestServer {
         let engine = Racer::new();
         let config = Config {
             port: 0,
-            secret_file: "/tmp/secret".to_string(),
+            secret_file: None,
             print_http_logs: true,
             rust_src_path: None,
         };

--- a/tests/util/http.rs
+++ b/tests/util/http.rs
@@ -1,4 +1,6 @@
 use std::ops::Deref;
+use std::fs::File;
+use std::io::Write;
 
 use libracerd::Config;
 use libracerd::engine::{Racer, SemanticEngine};
@@ -11,11 +13,11 @@ pub struct TestServer {
 }
 
 impl TestServer {
-    pub fn new() -> TestServer {
+    pub fn new(secret_file: Option<String>) -> TestServer {
         let engine = Racer::new();
         let config = Config {
             port: 0,
-            secret_file: None,
+            secret_file: secret_file,
             print_http_logs: true,
             rust_src_path: None,
         };
@@ -53,7 +55,25 @@ impl UrlBuilder for TestServer {
 }
 
 pub fn with_server<F>(mut func: F) where F: FnMut(&TestServer) -> () {
-    func(&TestServer::new());
+    func(&TestServer::new(None));
+}
+
+pub fn with_hmac_server<F>(secret: &str, mut func: F) where F: FnMut(&TestServer) -> () {
+    // Make a temp file unique to this test
+    let thread = ::std::thread::current();
+    let taskname = thread.name().unwrap();
+    let s = taskname.replace("::", "_");
+    let mut p = "secretfile.".to_string();
+    p.push_str(&s[..]);
+
+
+    {
+        let mut f = File::create(&p[..]).unwrap();
+        f.write_all(secret.as_bytes()).unwrap();
+        f.flush().unwrap();
+    }
+
+    func(&TestServer::new(Some(p)));
 }
 
 #[test]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,2 +1,30 @@
+use openssl::crypto::hash::Type;
+use openssl::crypto::hmac::hmac;
+use openssl::crypto::hmac::HMAC;
+
+use std::io::Write;
+
+use rustc_serialize::hex::ToHex;
+
 #[macro_use]
 pub mod http;
+
+pub fn hmac256(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    hmac(Type::SHA256, secret, data)
+}
+
+pub fn request_hmac(secret_str: &str, method: &str, path: &str, body: &str) -> String {
+    // hmac(hmac(GET) + hmac(/ping) + hmac())
+    let secret = secret_str.as_bytes();
+
+    let method_hmac = hmac256(secret, method.as_bytes());
+    let path_hmac = hmac256(secret, path.as_bytes());
+    let body_hmac = hmac256(secret, body.as_bytes());
+
+    let mut meta = HMAC::new(Type::SHA256, secret);
+    meta.write_all(&method_hmac[..]).unwrap();
+    meta.write_all(&path_hmac[..]).unwrap();
+    meta.write_all(&body_hmac[..]).unwrap();
+
+    meta.finish().to_hex()
+}


### PR DESCRIPTION
This adds HMAC authentication when the `--secret-file` option is present. The `--secret-file` option is not required. `racerd` will panic if the secret file does not exist or if there is an error reading the file.

## TODO
- [x] Test coverage