### PR TITLE
Add context and kind to find_definition

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,13 +156,17 @@ curl -H "Content-Type: application/json" -d '{"buffers":[{"file_path":"src.rs","
 | text      | string | Text of found definition                   |
 | line      | number | Line in file where definition was found    |
 | column    | number | Column in file where definition was found  |
+| context   | string | Surrounding text of definition             |
+| kind      | string | Type of definition                         |
 
 ```json
 {
   "file_path":"/Users/jwilm/rs/std/stable/libstd/path.rs",
   "column":11,
   "line":1267,
-  "text":"new"
+  "text":"new",
+  "context":"pub fn new<S: AsRef<OsStr> + ?Sized>(s: &S) -> &Path {",
+  "kind":"Function"
 }
 ```
 

--- a/src/http/definition.rs
+++ b/src/http/definition.rs
@@ -67,6 +67,8 @@ impl From<Definition> for FindDefinitionResponse {
             column: def.position.col,
             line: def.position.line,
             text: def.text,
+            context: def.text_context,
+            kind: def.dtype,
         }
     }
 }
@@ -110,4 +112,6 @@ struct FindDefinitionResponse {
     pub column: usize,
     pub line: usize,
     pub text: String,
+    pub context: String,
+    pub kind: String,
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -73,7 +73,9 @@ mod http {
                 "text": "foo",
                 "line": 1,
                 "column": 3,
-                "file_path": "src.rs"
+                "file_path": "src.rs",
+                "context": "fn foo() {}",
+                "kind": "Function"
             })).unwrap();
 
             // They should be equal
@@ -115,7 +117,9 @@ mod http {
                 "text": "myfn",
                 "line": 2,
                 "column": 7,
-                "file_path": "src2.rs"
+                "file_path": "src2.rs",
+                "context": "pub fn myfn()",
+                "kind": "Function"
             })).unwrap();
 
             // They should be equal


### PR DESCRIPTION
This pull-request adds "context" and "kind" to FindDefinitionRespons and closes #14. :)

