### PR TITLE
Collapsing whitespace in completion context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "persistent 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "racer 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.3"
 rand = "0.3"
 env_logger = "0.3"
 racer = "1.1"
+regex = "0.1.*"
 
 [dependencies.logger]
 git = "https://github.com/iron/logger.git"

--- a/src/engine/racer.rs
+++ b/src/engine/racer.rs
@@ -8,6 +8,7 @@ use racer::scopes::{coords_to_point, point_to_coords};
 use std::path::Path;
 
 use std::sync::Mutex;
+use regex::Regex;
 
 pub struct Racer<'a> {
     cache: Mutex<&'a FileCache<'a>>
@@ -133,7 +134,7 @@ impl<'a> SemanticEngine for Racer<'a> {
                     col: col
                 },
                 text: m.matchstr,
-                context: m.contextstr,
+                context: collapse_whitespace(&m.contextstr),
                 kind: format!("{:?}", m.mtype),
                 file_path: m.filepath.to_str().unwrap().to_string()
             }
@@ -145,6 +146,10 @@ impl<'a> SemanticEngine for Racer<'a> {
             Ok(None)
         }
     }
+}
+
+pub fn collapse_whitespace(text: &str) -> String {
+  Regex::new(r"\s+").unwrap().replace_all(text, " ")
 }
 
 unsafe impl<'a> Sync for Racer<'a> {}
@@ -213,5 +218,46 @@ mod tests {
         assert_eq!(completion.text, "myfn");
         assert_eq!(completion.position.line, 4);
         assert_eq!(completion.file_path, "src.rs");
+    }
+
+    #[test]
+    fn find_completion_collapsing_whitespace() {
+        let src = "
+            struct foo {}
+
+            impl foo {
+              fn format( &self )
+                -> u32 {
+              }
+            }
+
+            fn main() {
+              let x = foo{};
+              x.
+            }";
+
+        let buffers = vec![Buffer {
+            contents: src.to_string(),
+            file_path: "src.rs".to_string()
+        }];
+
+        let ctx = Context::new(buffers, CursorPosition { line: 12, col: 16 }, "src.rs");
+        let racer = Racer::new();
+
+        let completions = racer.list_completions(&ctx).unwrap().unwrap();
+        assert_eq!(completions.len(), 1);
+
+        let completion = &completions[0];
+        assert_eq!(completion.context, "fn format( &self ) -> u32");
+    }
+
+    #[test]
+    fn collapse_whitespace_test() {
+        assert_eq!(collapse_whitespace("foo  foo"), "foo foo");
+        assert_eq!(collapse_whitespace("  "), " ");
+        assert_eq!(collapse_whitespace("\n\t  \n"), " ");
+        assert_eq!(collapse_whitespace("foo\nbar"), "foo bar");
+        assert_eq!(collapse_whitespace("fn foo( &self )\n   -> u32"),
+                   "fn foo( &self ) -> u32");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ extern crate log;        // log macros
 extern crate racer;      // rust code analysis
 
 extern crate rand;
+extern crate regex;
 
 pub mod util;
 pub mod http;


### PR DESCRIPTION
Without this fix, racerd would return lots of whitespace in the
completion context if the user requested completion for a function like
the following:
```rust
fn format( &self )
    -> u32 { }
```

All the whitespace between `)` and `->` (including the newline) would be
preserved. That's not what the user wants so we now collapse all runs of
whitespace chars to a single space.

Fixes #21.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jwilm/racerd/22)
<!-- Reviewable:end -->
