### PR TITLE
Reading the secret key as a byte sequence

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -13,6 +13,7 @@ use ::engine::SemanticEngine;
 
 use iron::typemap::Key;
 use iron_hmac::Hmac256Authentication;
+use iron_hmac::SecretKey;
 
 /// Errors occurring in the http module
 #[derive(Debug)]
@@ -80,7 +81,7 @@ pub fn serve<E: SemanticEngine + 'static>(config: &Config, engine: E) -> Result<
 
     // Get HMAC Middleware
     let (hmac_before, hmac_after) = if config.secret_file.is_some() {
-        let secret = config.read_secret_file();
+        let secret = SecretKey::new(&config.read_secret_file());
         let hmac_header = "x-racerd-hmac";
         let (before, after) = Hmac256Authentication::middleware(secret, hmac_header);
         (Some(before), Some(after))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,12 +67,12 @@ impl Config {
     /// Return contents of secret file
     ///
     /// panics if self.secret_file is None or an error is encountered while reading the file.
-    pub fn read_secret_file(&self) -> String {
+    pub fn read_secret_file(&self) -> Vec<u8> {
         self.secret_file.as_ref().map(|secret_file_path| {
             let buf = {
                 let mut f = File::open(secret_file_path).unwrap();
-                let mut buf = String::new();
-                f.read_to_string(&mut buf).unwrap();
+                let mut buf = Vec::new();
+                f.read_to_end(&mut buf).unwrap();
                 buf
             };
 


### PR DESCRIPTION
Currently, it's being read as a String, which enforces that the contents
of the secret file must be UTF-8. That's a needless restriction.

Fixes #24