### PR TITLE
Fix PoisonError unwrap in http/definition

### DIFF
--- a/src/http/definition.rs
+++ b/src/http/definition.rs
@@ -36,7 +36,7 @@ pub fn find(req: &mut Request) -> IronResult<Response> {
     };
 
     let mutex = req.get::<::persistent::Write<EngineProvider>>().unwrap();
-    let engine = mutex.lock().unwrap();
+    let engine = mutex.lock().unwrap_or_else(|e| e.into_inner());
     match engine.find_definition(&fdr.context()) {
         // 200 OK; found the definition
         Ok(Some(definition)) => {


### PR DESCRIPTION
This appears to be the last place where PoisonError was being ignored.