### PR TITLE
fix build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ router = "0.6.0"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"
-rls-span = "0.4"
+rls-span = "0.5"
 
 [dev-dependencies]
 rust-crypto = "0.2.36"

--- a/src/engine/my_racer.rs
+++ b/src/engine/my_racer.rs
@@ -44,7 +44,7 @@ impl SemanticEngine for Racer {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let session = Session::new(&cache);
+        let session = Session::new(&cache, None);
         for buffer in &ctx.buffers {
             session.cache_file_contents(buffer.path(), &*buffer.contents)
         }
@@ -74,7 +74,7 @@ impl SemanticEngine for Racer {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let session = Session::new(&cache);
+        let session = Session::new(&cache, None);
         for buffer in &ctx.buffers {
             session.cache_file_contents(buffer.path(), &*buffer.contents)
         }


### PR DESCRIPTION
1. rls-span version has to keep up with racer (0.5.2 for now).
2. racer::Session() needs two arguments now.