### PR TITLE
[Bug Fix] racerd not able to complete cargo crates

### DIFF
--- a/src/engine/error.rs
+++ b/src/engine/error.rs
@@ -18,7 +18,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::IoError(ref err) => Some(err),
             Error::Racer => None,

--- a/src/engine/my_racer.rs
+++ b/src/engine/my_racer.rs
@@ -44,7 +44,7 @@ impl SemanticEngine for Racer {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let session = Session::new(&cache, None);
+        let session = Session::new(&cache, Some(ctx.query_path()));
         for buffer in &ctx.buffers {
             session.cache_file_contents(buffer.path(), &*buffer.contents)
         }
@@ -74,7 +74,7 @@ impl SemanticEngine for Racer {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let session = Session::new(&cache, None);
+        let session = Session::new(&cache, Some(ctx.query_path()));
         for buffer in &ctx.buffers {
             session.cache_file_contents(buffer.path(), &*buffer.contents)
         }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -37,7 +37,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct EngineProvider;
 
 impl Key for EngineProvider {
-    type Value = Box<SemanticEngine + Send + Sync + 'static>;
+    type Value = Box<dyn SemanticEngine + Send + Sync + 'static>;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -95,7 +95,7 @@ pub fn serve<E: SemanticEngine + Send + Sync + 'static>(
 
     // This middleware provides a semantic engine to the request handlers
     // where Box<E>: PersistentInto<Arc<Mutex<Box<SemanticEngine + Sync + Send + 'static>>>>
-    let x: Arc<Mutex<Box<SemanticEngine + Sync + Send + 'static>>> =
+    let x: Arc<Mutex<Box<dyn SemanticEngine + Sync + Send + 'static>>> =
         Arc::new(Mutex::new(Box::new(engine)));
     chain.link_before(Write::<EngineProvider>::one(x));
 


### PR DESCRIPTION
Hi， @jwilm 
Sorry about the [#80](https://github.com/jwilm/racerd/pull/80/commits/236a4ac959e24d3e6ed68e7975dca1b5ca80c962)  that the fix is not right. I was about to learn Rust at that time, and I saw some code snippets like Session::new(..., None)  from [racer-rust/racer](racer-rust/racer/), so I just copy the snippets without fullly understanding of the code.

Actually, the second arg should be full path of the source file, otherwise racer will not return completions for cargo crates.

In addition, add 'dyn' to some code to get rid of the deprecated warnings